### PR TITLE
Feat: 이름입력시 서비스 이용가능하게 하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,24 @@
-import ChatList from 'components/ChatList';
-import { mockData } from 'components/ChatList/mockData';
 import React from 'react';
+import InputName from 'components/InputName';
+import { useSelector } from 'react-redux';
+import { RootState } from 'store/store';
+import ModalPortal from './components/shared/ModalPortal';
+import Modal from './components/shared/Modal';
 
 function App() {
+  const { isLoggedIn } = useSelector(
+    (state: RootState) => state.messenger.currentUser,
+  );
+
   return (
     <div>
-      <ChatList messages={mockData} />
+      {!isLoggedIn && (
+        <ModalPortal>
+          <Modal>
+            <InputName />
+          </Modal>
+        </ModalPortal>
+      )}
     </div>
   );
 }

--- a/src/components/InputName/index.tsx
+++ b/src/components/InputName/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { addCurrentUser } from 'store/messenger';
-import * as Styled from './styled';
+import * as S from './styled';
 
 function InputName() {
   const [inputValue, setInputValue] = useState('');
@@ -18,17 +18,17 @@ function InputName() {
   };
 
   return (
-    <Styled.InputNameContainer>
-      <Styled.ExplainText>이름을 입력해주세요.</Styled.ExplainText>
-      <Styled.NameInputForm onSubmit={handleSubmit}>
-        <Styled.NameInput
+    <S.InputNameContainer>
+      <S.ExplainText>이름을 입력해주세요.</S.ExplainText>
+      <S.NameInputForm onSubmit={handleSubmit}>
+        <S.NameInput
           value={inputValue}
           placeholder="한글자 이상 입력해주세요"
           onChange={handleChange}
         />
-        <Styled.Button onClick={handleSubmit}>확인</Styled.Button>
-      </Styled.NameInputForm>
-    </Styled.InputNameContainer>
+        <S.Button onClick={handleSubmit}>확인</S.Button>
+      </S.NameInputForm>
+    </S.InputNameContainer>
   );
 }
 export default InputName;

--- a/src/components/shared/Modal/index.tsx
+++ b/src/components/shared/Modal/index.tsx
@@ -8,7 +8,7 @@ function Modal({ children, onClose }: ModalProps) {
     <Styled.Background onClick={onClose}>
       <Styled.ModalContainer>
         <Styled.CloseButton>
-          <IoMdClose onClick={onClose} />
+          {onClose && <IoMdClose onClick={onClose} />}
         </Styled.CloseButton>
         {children}
       </Styled.ModalContainer>

--- a/src/components/shared/Modal/types.ts
+++ b/src/components/shared/Modal/types.ts
@@ -1,4 +1,4 @@
 export interface ModalProps {
   children: React.ReactNode;
-  onClose: () => void;
+  onClose?: () => void;
 }

--- a/src/store/messenger.ts
+++ b/src/store/messenger.ts
@@ -45,16 +45,13 @@ export const messengerSlice = createSlice({
   reducers: {
     // 메시지 입력
     addNewMessage: (state, action: PayloadAction<string>) => {
-      if (!state.currentMessage) {
-        const newMessage = {
-          id: Date.now(),
-          date: new Date().toString(),
-          user: state.currentUser,
-          content: action.payload,
-        } as Message;
-        state.messages = [...state.messages, newMessage]; // 원래로직
-        return state;
-      }
+      const newMessage = {
+        id: Date.now(),
+        date: new Date().toString(),
+        user: state.currentUser,
+        content: action.payload,
+      } as Message;
+      state.messages = [...state.messages, newMessage]; // 원래로직
     },
     // 메시지 삭제
     removeMessage: (state, action: PayloadAction<number>) => {


### PR DESCRIPTION
구현 내용
1. 이름입력해야만 서비스를 이용할 수 있게 했습니다.
2. 기존 modal컴포넌트에 onClose를 받을 수 있어야됐는데, 이름입력은 무조건 받아야되기 때문에 onClose함수가 항상 필요하지 않는것을 발견했습니다. 삭제모달과 이름모달의 확장성을 고려하여 onClose함수에 옵셔널을 추가했습니다.
3. 기존 messengerSlice에서 addNewMessage가 잘못 되어있어 핫픽스했습니다.
